### PR TITLE
Adding practice website to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ quantified roughly as follows:
 * [pandas_basics](https://github.com/vi3k6i5/pandas_basics)
 * [first-python-notebook](https://github.com/california-civic-data-coalition/first-python-notebook)
 * [Learn Pandas](https://bitbucket.org/hrojas/learn-pandas)
-
+*_[Pandas practice website](https://pandaspractice.com/)
 
 
 ### (1.4) :blue_book: Books / papers


### PR DESCRIPTION
I stumbled upon a website that focuses on some pandas exercises when browsing Reddit one day. Link to [Reddit thread here](https://www.reddit.com/r/learnpython/comments/k7b25d/exercises_to_learn_pandas/) Admittedly I did not use it much, but perhaps it would fit well in this repo!