### PR TITLE
Add pandera and pandas-vet to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,3 +284,5 @@ Every video is below.
 ## (4) Packages
 
 - [datatest](https://github.com/shawnbrown/datatest) - Tools for test driven data-wrangling and data validation (DataFrame, Series, Index, MultiIndex).
+- [pandera](https://github.com/pandera-dev/pandera) - A light-weight, flexible, and expressive data validation library for dataframes.
+- [pandas-vet](https://github.com/deppen8/pandas-vet) - A plugin for Flake8 that checks pandas code.


### PR DESCRIPTION
From the pandera README:

"Dataframes contain information that pandera explicitly validates at runtime. This is useful in production-critical or reproducible research settings."

From the pandas-vet README:

"pandas-vet is (hopefully) a way to help make pandas a little more friendly for newcomers by taking some opinionated stances about pandas best practices. It is designed to help users reduce the pandas universe."

The list you made here is great and the first thing I found when searching for "awesome pandas". Selfishly, I don't want to have to remember how to find pandera and pandas-vet next time I deal with pandas, and they also seemed like they might be generally useful to others.